### PR TITLE
Add SameSite and Secure attribute to Cookie

### DIFF
--- a/assets/src/js/tracker.js
+++ b/assets/src/js/tracker.js
@@ -64,7 +64,7 @@
       str += ';expires='+args.expires.toUTCString();
     }
 
-    document.cookie = str;
+    document.cookie = str + ';SameSite=None;Secure';
   }
 
   function newVisitorData() {


### PR DESCRIPTION
After self-hosting fathom and adding the script to my website, I noticed the following error in my console:

> A cookie associated with a cross-site resource at http://n6k5qhs8vh78z613g8fkvgsdghbsd.herokuapp.com/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.

I referred to this https://github.com/GoogleChromeLabs/samesite-examples/blob/master/javascript.md to add the SameSite and Secure attribute in Javascript.